### PR TITLE
Add missing <pthread.h>. This has been prohibiting building atom on Darwin

### DIFF
--- a/base.gyp
+++ b/base.gyp
@@ -9,7 +9,7 @@
         ],
         'xcode_settings': {
           'CLANG_CXX_LANGUAGE_STANDARD': 'gnu++11',
-          'CLANG_CXX_LIBRARY': 'libstdc++',
+          'CLANG_CXX_LIBRARY': 'libc++',
         },
         'cflags_cc': [
           '-std=c++0x',
@@ -20,7 +20,7 @@
       ],
       'xcode_settings': {
         'CLANG_CXX_LANGUAGE_STANDARD': 'gnu++11',
-        'CLANG_CXX_LIBRARY': 'libstdc++',
+        'CLANG_CXX_LIBRARY': 'libc++',
       },
       'cflags_cc': [
         '-std=c++0x',

--- a/src/base/threading/thread_collision_warner.cc
+++ b/src/base/threading/thread_collision_warner.cc
@@ -8,6 +8,7 @@
 
 #if defined(OS_MACOSX)
 #include <sys/resource.h>
+#include <pthread.h>
 #endif
 
 #if defined(OS_LINUX)


### PR DESCRIPTION
:apple: :bug:
Also, in Xcode settings, change libstdc++ to libc++ —  Apple's libstdc++ is a legacy library from GCC 4.2.1, and has no c++11 support.